### PR TITLE
Formatting cleanup, fix test, add new test, and cleanup safely after test run

### DIFF
--- a/test
+++ b/test
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-tail -n +2 third_party.go > third_party_tmp.go
+TEST_FILE="third_party_tmp.go"
+trap "rm -f $TEST_FILE" SIGINT SIGTERM EXIT
+tail -n +2 third_party.go > $TEST_FILE
 go test -v .
-rm third_party_tmp.go

--- a/third_party.go
+++ b/third_party.go
@@ -155,14 +155,18 @@ type vcHg string
 
 // vcHg.commit returns the current HEAD commit hash for a given hg dir.
 func (v vcHg) commit() string {
-	out, err := exec.Command("hg", "id", "-i", "-R", string(v)).Output()
+	out, err := exec.Command("hg",
+		"id",
+		"-i",
+		"-R", string(v),
+	).Output()
 	if err != nil {
 		return ""
 	}
 	return string(out)
 }
 
-// vcHg.udpate updates the given hg dir to ref.
+// vcHg.update updates the given hg dir to ref.
 func (v vcHg) update(ref string) error {
 	_, err := exec.Command("hg",
 		"update",
@@ -180,7 +184,12 @@ type vcGit string
 
 // vcGit.commit returns the current HEAD commit hash for a given git dir.
 func (v vcGit) commit() string {
-	out, err := exec.Command("git", "--git-dir="+string(v), "rev-parse", "HEAD").Output()
+	out, err := exec.Command(
+		"git",
+		"--git-dir="+string(v),
+		"rev-parse",
+		"HEAD",
+	).Output()
 	if err != nil {
 		return ""
 	}
@@ -292,8 +301,7 @@ func bump(pkg, version string) {
 // validPkg uses go list to decide if the given path is a valid go package.
 // This is used by the bumpAll walk to bump all of the existing packages.
 func validPkg(pkg string) bool {
-	env := append(os.Environ(),
-	)
+	env := append(os.Environ())
 	cmd := exec.Command("go", "list", pkg)
 	cmd.Env = env
 

--- a/third_party.go
+++ b/third_party.go
@@ -99,17 +99,17 @@ func setupProject(pkg string) {
 		log.Fatalf("Failed to get the current working directory: %v", err)
 	}
 
-	src := path.Join(thirdPartyDir(), "src", pkg)
-	srcdir := path.Dir(src)
+	pkgsrc := path.Join(srcDir(), pkg)
+	pkgsrcdir := path.Dir(pkgsrc)
 
-	os.MkdirAll(srcdir, 0755)
+	os.MkdirAll(pkgsrcdir, 0755)
 
-	rel, err := filepath.Rel(srcdir, root)
+	rel, err := filepath.Rel(pkgsrcdir, root)
 	if err != nil {
 		log.Fatalf("creating relative third party path: %v", err)
 	}
 
-	err = os.Symlink(rel, src)
+	err = os.Symlink(rel, pkgsrc)
 	if err != nil && os.IsExist(err) == false {
 		log.Fatalf("creating project third party symlink: %v", err)
 	}
@@ -196,7 +196,7 @@ func (v vcGit) commit() string {
 	return string(out)
 }
 
-// vcHg.udpate updates the given git dir to ref.
+// vcHg.update updates the given git dir to ref.
 func (v vcGit) update(ref string) error {
 	_, err := exec.Command("git",
 		"--work-tree="+path.Dir(string(v)),


### PR DESCRIPTION
fun fact: ioutil.TempDir(TestDir, "removeVcs") was never succeeding because TestDir doesn't exist (this failure then silently passed through the rest of the test, which is why it leaves behind a "github.com/removeVcs" directory). This change moves the tests to actually run in a temp directory that gets cleaned up. And I added a dumb test - it's the first go code I've written that actually does anything, so idiomaticity may be missing.
